### PR TITLE
Add spec implementation and fuzzing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _opam
 \#*#
 *.install
 .merlin
+test/afl/outputs

--- a/SPEC.md
+++ b/SPEC.md
@@ -172,9 +172,9 @@ An inode value contains a flat list of tree entries.
 
 As already described, **a tree entry is a triplet: *name $\times$ kind $\times$ hash*.** The encoding for inode entries is more compact than for node entries. For inodes, entries are encoded as follows:
 
-|  `(LEB128)`  | `len(name)` |   1    |   32   |
-|:------------:|:-----------:|:------:|:------:|
-| `\len(name)` |   `name`    | `kind` | `hash` |
+|  `(LEB128)`  | `len(name)` | `(LEB128)` |   32   |
+|:------------:|:-----------:|:----------:|:------:|
+| `\len(name)` |   `name`    |   `kind`   | `hash` |
 
 where *kind* is `\000` for nodes, and `\001` for contents.
 
@@ -190,9 +190,9 @@ where *kind* is `\000` for nodes, and `\001` for contents.
 
 **An inode value is a list of at most 32 entries, sorted by lexicographic order of names.** A value with $n$ entries $e_1$, $e_2$, ... $e_n$ is encoded as follows when $n \leq 32$:
 
-|   1    |  1   |     $n_1$      | ... |     $n_k$      |
-|:------:|:----:|:--------------:|:---:|:--------------:|
-| `\000` | `\n` | `encode(_1)` | ... | `encode(e_k)` |
+|   1    |  `(LEB128)`  |     $n_1$      | ... |     $n_k$      |
+|:------:|:-----------: |:--------------:|:---:|:--------------:|
+| `\000` |     `\n`     | `encode(_1)` | ... | `encode(e_k)` |
 
 where *$n_i$ = len(encode$e_i$))* and *name($e_1$) $\le$ ... $\le$ name($e_n$)*. Hence all names must be different.
 
@@ -202,9 +202,9 @@ Inode trees contain a list of inode pointers
 
 **An inode pointer is a pair: *index $\times$ hash*.** *index* is always less than 32. A pointer is encoded as follows:
 
-|    1    |   32   |
-|:-------:|:------:|
-| `index` | `hash` |
+| `(LEB128)` |   32   |
+|:----------:|:------:|
+|  `index`   | `hash` |
 
 **An inode tree is a triplet: *depth $\times$ len(entries) $\times$ pointers*.** The number of pointers is always less than or equal to 32. $pointers$ is a sparse list of pointers: every pointer in the list has a distinct index and the list is ordered by increasing indices, but some indices might be missing. Moreover, `len(entries)` aggregates the total number of entries that are reachable via the pointers. This information can for instance be used to decide whenever an inode value has to be converted into a inode tree (or the reverse) when a new entry is added (or removed) from the tree.
 

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,6 +1,6 @@
 open Irmin_tezos
 open Schema
-module Node = Store.Backend.Node.Val
+module Node = Store.Private.Node.Val
 module Inter = Irmin_pack.Inode.Make_internal (Conf) (Hash) (Node)
 
 module Spec = struct

--- a/lib/dune
+++ b/lib/dune
@@ -1,0 +1,4 @@
+(library
+ (public_name tezos-context-hash)
+ (name tezos_context_hash)
+ (libraries digestif))

--- a/lib/tezos_context_hash.ml
+++ b/lib/tezos_context_hash.ml
@@ -189,7 +189,7 @@ let index d n = ocaml_hash d n mod 32
 
 type inode = Empty | Value of inode_value | Tree of inode_tree
 
-(** This implements the computation of $X_{d,j}$. *)
+(** This implements the computation of $X_\{d,j\}$. *)
 let filter x d j = List.filter (fun { name; _ } -> index d name = j) x
 
 let rec partition d x =

--- a/test/afl/inputs/000
+++ b/test/afl/inputs/000
@@ -1,0 +1,1 @@
+¡9Êö§=¾¥þƒÑÞWcùG­áÈË¥ÐU‰´g<å6É‡Õ©8Ù°‹ìcZcƒm"XÂI¤¯Šo÷œE*³†H=*/GS+žY1âR`¹á›þ{Y«®·˜¼s“

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,7 @@
 (executable
  (name main)
- (public_name irmin-hash-fuzz)
- (libraries pprint monolith irmin_tezos))
+ (libraries tezos-context-hash irmin irmin-tezos irmin-pack pprint monolith))
+
+(alias
+ (name runtest)
+ (deps main.exe))

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,4 @@
+(executable
+ (name main)
+ (public_name irmin-hash-fuzz)
+ (libraries pprint monolith irmin_tezos))

--- a/test/main.ml
+++ b/test/main.ml
@@ -2,39 +2,52 @@ open Monolith
 
 module type Testable = sig
   val fixed_int : int -> string
+  val leb128_int : int -> string
   val contents : bytes -> string
 end
 
-module C = Spec
+module C : Testable = Spec
 
-module R = struct
+module R : Testable = struct
+  open Irmin.Type
+
   let fixed_int i =
     let buf = Bytes.create 8 in
-    Irmin.Type.(unstage (encode_bin int64)) (Int64.of_int i) (fun s ->
+    unstage (encode_bin int64) (Int64.of_int i) (fun s ->
         Bytes.blit_string s 0 buf 0 8);
     Bytes.unsafe_to_string buf
 
+  let leb128_int i =
+    let buf = Buffer.create 8 in
+    unstage (encode_bin int) i (Buffer.add_string buf);
+    Buffer.contents buf
+
   let contents b =
-    let buf = Buffer.create 0 in
-    Irmin.Type.(unstage (pre_hash Irmin_tezos.Encoding.Contents.t)) b (fun s ->
-        Buffer.add_string buf s);
+    let buf = Buffer.create (8 + Bytes.length b) in
+    (unstage (pre_hash Irmin_tezos.Encoding.Contents.t))
+      b (Buffer.add_string buf);
     Buffer.contents buf
 end
+
+let positive_int = int_within (Gen.int Int.max_int)
 
 let bytes =
   easily_constructible
     (fun () -> Bytes.of_string (Gen.string (Gen.int (1 lsl 20)) Gen.char ()))
-    (fun _ -> PPrint.empty)
+    (fun b -> PPrint.string (Bytes.to_string b))
 
 let string = deconstructible PPrint.string
 let check_size s = String.length s > 10
 
 let () =
-  let spec = bytes ^> string in
-  declare "contents" spec R.contents C.contents;
+  let spec = positive_int ^> string in
+  declare "fixed int" spec R.fixed_int C.fixed_int;
 
-  let spec = int_within (Gen.int (1 lsl 20)) ^> string in
-  declare "fixed int" spec R.fixed_int C.fixed_int
+  let spec = positive_int ^> string in
+  declare "LEB128 int" spec R.leb128_int C.leb128_int;
+
+  let spec = bytes ^> string in
+  declare "contents" spec R.contents C.contents
 
 let () =
   let fuel = 10 in

--- a/test/main.ml
+++ b/test/main.ml
@@ -17,7 +17,13 @@ end
 
 module C : Testable = Spec
 
-module R : Testable = struct
+module R :
+  Testable
+    with type hash = C.hash
+     and type commit_metadata = C.commit_metadata
+     and type commit = C.commit
+     and type entry_kind = C.entry_kind
+     and type tree_entry = C.tree_entry = struct
   type hash = string
 
   let with_encoder encoder x =
@@ -45,8 +51,17 @@ module R : Testable = struct
     in
     with_encoder encode
 
-  type commit_metadata = { date : int64; author : string; message : string }
-  type commit = { tree : hash; parents : hash list; metadata : commit_metadata }
+  type commit_metadata = C.commit_metadata = {
+    date : int64;
+    author : string;
+    message : string;
+  }
+
+  type commit = C.commit = {
+    tree : hash;
+    parents : hash list;
+    metadata : commit_metadata;
+  }
 
   let commit =
     let encode =
@@ -62,13 +77,24 @@ module R : Testable = struct
     in
     fun c -> with_encoder encode (to_irmin_commit c)
 
-  type entry_kind = Content | Node
-  type tree_entry = { name : string; kind : entry_kind; hash : hash }
+  type entry_kind = C.entry_kind = Content | Node
+
+  type tree_entry = C.tree_entry = {
+    name : string;
+    kind : entry_kind;
+    hash : hash;
+  }
 
   let ocaml_hash = Hashtbl.seeded_hash
 
+  module Inter =
+    Irmin_pack.Private.Inode.Make_intermediate
+      (Irmin_tezos.Conf)
+      (Irmin_tezos.Encoding.Hash)
+      (Irmin_tezos.Encoding.Node)
+
   let tree =
-    let encode = Irmin.Type.(unstage (pre_hash Irmin_tezos.Encoding.Node.t)) in
+    let encode = Irmin.Type.(unstage (pre_hash Inter.Val.t)) in
     let to_irmin_entry { name; kind; hash } =
       let hash = to_irmin_hash hash in
       ( name,
@@ -76,28 +102,103 @@ module R : Testable = struct
         | Content -> `Contents (hash, Irmin_tezos.Encoding.Metadata.default)
         | Node -> `Node hash )
     in
-    let to_irmin_tree l =
-      List.map to_irmin_entry l |> Irmin_tezos.Encoding.Node.v
-    in
+    let to_irmin_tree l = List.map to_irmin_entry l |> Inter.Val.v in
     fun t -> with_encoder encode (to_irmin_tree t)
+end
+
+(** Custom generators absent from Monolith *)
+module G = struct
+  let hash () = Gen.string (fun () -> 32) Gen.char ()
+  let string () = Gen.string (Gen.closed_interval 1 64) Gen.char ()
+  let bytes () = Bytes.of_string (string ())
+  let int64 () = Int64.of_int (Gen.int Int.max_int ())
+
+  let commit_metadata () =
+    C.{ date = int64 (); author = string (); message = string () }
+
+  let commit () =
+    {
+      C.tree = hash ();
+      C.parents = Gen.list (Gen.closed_interval 1 32) hash ();
+      C.metadata = commit_metadata ();
+    }
+
+  let tree_entry () =
+    {
+      C.name = string ();
+      C.kind = Gen.choose [ C.Content; C.Node ] ();
+      C.hash = hash ();
+    }
+end
+
+(** Custom printers absent from PPrint *)
+module P = struct
+  open PPrintOCaml
+
+  let commit_metadata C.{ date; author; message } =
+    record ""
+      [
+        ("date", int64 date);
+        ("author", string author);
+        ("message", string message);
+      ]
+
+  let commit C.{ tree; parents; metadata } =
+    record ""
+      [
+        ("tree", string tree);
+        ("parents", (list string) parents);
+        ("metadata", commit_metadata metadata);
+      ]
+
+  let tree_entry C.{ name; kind; hash } =
+    record ""
+      [
+        ("name", string name);
+        ( "kind",
+          string (match kind with Node -> "Node" | Content -> "Content") );
+        ("hash", string hash);
+      ]
 end
 
 let positive_int = int_within (Gen.int Int.max_int)
 
 let bytes =
-  easily_constructible
-    (fun () ->
-      Bytes.unsafe_of_string (Gen.string (Gen.int (1 lsl 5)) Gen.char ()))
-    (fun b -> PPrintOCaml.string (Bytes.to_string b))
+  easily_constructible G.bytes (fun b ->
+      PPrintOCaml.string (Bytes.unsafe_to_string b))
 
 let string =
-  let neg =
-    easily_constructible
-      (Gen.string (Gen.int (1 lsl 5)) Gen.char)
-      PPrintOCaml.string
-  in
-  let pos = deconstructible PPrint.string in
+  let neg = easily_constructible G.string PPrintOCaml.string in
+  let pos = deconstructible PPrintOCaml.string in
   ifpol neg pos
+
+let int64 =
+  easily_constructible G.int64 (fun i -> PPrint.string (Int64.to_string i))
+
+let commit_metadata = easily_constructible G.commit_metadata P.commit_metadata
+let commit = easily_constructible G.commit P.commit
+let tree_entry = easily_constructible G.tree_entry P.tree_entry
+
+let distinct_names =
+  let tbl = Hashtbl.create 0 in
+  fun l ->
+    Hashtbl.clear tbl;
+    let rec loop = function
+      | [] -> true
+      | h :: t ->
+          let name = h.C.name in
+          if Hashtbl.mem tbl name then false
+          else (
+            Hashtbl.add tbl name ();
+            loop t)
+    in
+    loop l
+
+let short_entry_list =
+  distinct_names % list ~length:(Gen.closed_interval 1 256) tree_entry
+
+let long_entry_list =
+  distinct_names % list ~length:(Gen.closed_interval 257 1024) tree_entry
 
 let () =
   let spec = positive_int ^> string in
@@ -107,10 +208,19 @@ let () =
   declare "LEB128 int" spec R.leb128_int C.leb128_int;
 
   let spec = bytes ^> string in
-  declare "contents" spec R.content C.content;
+  declare "content" spec R.content C.content;
 
-  let spec = string ^> int in
-  declare "ocaml_hash" spec (R.ocaml_hash 0) (C.ocaml_hash 0)
+  let spec = commit ^> string in
+  declare "commit" spec R.commit C.commit;
+
+  let spec = positive_int ^> string ^> int in
+  declare "ocaml_hash" spec R.ocaml_hash C.ocaml_hash;
+
+  let spec = short_entry_list ^> string in
+  declare "node" spec R.tree C.tree;
+
+  let spec = long_entry_list ^> string in
+  declare "inode" spec R.tree C.tree
 
 let () =
   let fuel = 10 in

--- a/test/main.ml
+++ b/test/main.ml
@@ -60,14 +60,13 @@ module R : Testable = struct
     let encode = Irmin.Type.(unstage (pre_hash Schema.Contents.t)) in
     with_encoder encode
 
-  module Key = Irmin.Key.Of_hash (Schema.Hash)
-  module Commit = Schema.Commit (Key) (Key)
-  module Node = Schema.Node (Key) (Key)
+  module Commit = Schema.Commit (Schema.Hash)
+  module Node = Schema.Node (Schema.Hash) (Schema.Path) (Schema.Metadata)
 
   let commit =
     let encode = Irmin.Type.(unstage (pre_hash Commit.t)) in
     let to_irmin_metadata { date; author; message } =
-      Irmin_tezos.Schema.Info.v ~message ~author date
+      Irmin.Info.v ~author ~date message
     in
     let to_irmin_commit { tree; parents; metadata } =
       let info = to_irmin_metadata metadata in

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,43 +1,103 @@
 open Monolith
 
 module type Testable = sig
+  type hash = string
+  type commit_metadata = { date : int64; author : string; message : string }
+  type commit = { tree : hash; parents : hash list; metadata : commit_metadata }
+  type entry_kind = Content | Node
+  type tree_entry = { name : string; kind : entry_kind; hash : hash }
+
   val fixed_int : int -> string
   val leb128_int : int -> string
-  val contents : bytes -> string
+  val content : bytes -> string
+  val commit : commit -> string
+  val ocaml_hash : int -> string -> int
+  val tree : tree_entry list -> string
 end
 
 module C : Testable = Spec
 
 module R : Testable = struct
-  open Irmin.Type
+  type hash = string
 
-  let fixed_int i =
-    let buf = Bytes.create 8 in
-    unstage (encode_bin int64) (Int64.of_int i) (fun s ->
-        Bytes.blit_string s 0 buf 0 8);
-    Bytes.unsafe_to_string buf
-
-  let leb128_int i =
-    let buf = Buffer.create 8 in
-    unstage (encode_bin int) i (Buffer.add_string buf);
+  let with_encoder encoder x =
+    let buf = Buffer.create 0 in
+    encoder x (Buffer.add_string buf);
     Buffer.contents buf
 
-  let contents b =
-    let buf = Buffer.create (8 + Bytes.length b) in
-    (unstage (pre_hash Irmin_tezos.Encoding.Contents.t))
-      b (Buffer.add_string buf);
-    Buffer.contents buf
+  let to_irmin_hash =
+    let encode =
+      Irmin.Type.(unstage (of_bin_string Irmin_tezos.Encoding.Hash.t))
+    in
+    fun x -> encode x |> Result.get_ok
+
+  let fixed_int =
+    let encode = Irmin.Type.(unstage (encode_bin int64)) in
+    fun i -> with_encoder encode (Int64.of_int i)
+
+  let leb128_int =
+    let encode = Irmin.Type.(unstage (encode_bin int)) in
+    with_encoder encode
+
+  let content =
+    let encode =
+      Irmin.Type.(unstage (pre_hash Irmin_tezos.Encoding.Contents.t))
+    in
+    with_encoder encode
+
+  type commit_metadata = { date : int64; author : string; message : string }
+  type commit = { tree : hash; parents : hash list; metadata : commit_metadata }
+
+  let commit =
+    let encode =
+      Irmin.Type.(unstage (pre_hash Irmin_tezos.Encoding.Commit.t))
+    in
+    let to_irmin_metadata { date; author; message } =
+      Irmin.Info.v ~date ~author message
+    in
+    let to_irmin_commit { tree; parents; metadata } =
+      let info = to_irmin_metadata metadata in
+      Irmin_tezos.Encoding.Commit.v ~info ~node:(to_irmin_hash tree)
+        ~parents:(List.map to_irmin_hash parents)
+    in
+    fun c -> with_encoder encode (to_irmin_commit c)
+
+  type entry_kind = Content | Node
+  type tree_entry = { name : string; kind : entry_kind; hash : hash }
+
+  let ocaml_hash = Hashtbl.seeded_hash
+
+  let tree =
+    let encode = Irmin.Type.(unstage (pre_hash Irmin_tezos.Encoding.Node.t)) in
+    let to_irmin_entry { name; kind; hash } =
+      let hash = to_irmin_hash hash in
+      ( name,
+        match kind with
+        | Content -> `Contents (hash, Irmin_tezos.Encoding.Metadata.default)
+        | Node -> `Node hash )
+    in
+    let to_irmin_tree l =
+      List.map to_irmin_entry l |> Irmin_tezos.Encoding.Node.v
+    in
+    fun t -> with_encoder encode (to_irmin_tree t)
 end
 
 let positive_int = int_within (Gen.int Int.max_int)
 
 let bytes =
   easily_constructible
-    (fun () -> Bytes.of_string (Gen.string (Gen.int (1 lsl 20)) Gen.char ()))
-    (fun b -> PPrint.string (Bytes.to_string b))
+    (fun () ->
+      Bytes.unsafe_of_string (Gen.string (Gen.int (1 lsl 5)) Gen.char ()))
+    (fun b -> PPrintOCaml.string (Bytes.to_string b))
 
-let string = deconstructible PPrint.string
-let check_size s = String.length s > 10
+let string =
+  let neg =
+    easily_constructible
+      (Gen.string (Gen.int (1 lsl 5)) Gen.char)
+      PPrintOCaml.string
+  in
+  let pos = deconstructible PPrint.string in
+  ifpol neg pos
 
 let () =
   let spec = positive_int ^> string in
@@ -47,7 +107,10 @@ let () =
   declare "LEB128 int" spec R.leb128_int C.leb128_int;
 
   let spec = bytes ^> string in
-  declare "contents" spec R.contents C.contents
+  declare "contents" spec R.content C.content;
+
+  let spec = string ^> int in
+  declare "ocaml_hash" spec (R.ocaml_hash 0) (C.ocaml_hash 0)
 
 let () =
   let fuel = 10 in

--- a/test/main.ml
+++ b/test/main.ml
@@ -1,0 +1,41 @@
+open Monolith
+
+module type Testable = sig
+  val fixed_int : int -> string
+  val contents : bytes -> string
+end
+
+module C = Spec
+
+module R = struct
+  let fixed_int i =
+    let buf = Bytes.create 8 in
+    Irmin.Type.(unstage (encode_bin int64)) (Int64.of_int i) (fun s ->
+        Bytes.blit_string s 0 buf 0 8);
+    Bytes.unsafe_to_string buf
+
+  let contents b =
+    let buf = Buffer.create 0 in
+    Irmin.Type.(unstage (pre_hash Irmin_tezos.Encoding.Contents.t)) b (fun s ->
+        Buffer.add_string buf s);
+    Buffer.contents buf
+end
+
+let bytes =
+  easily_constructible
+    (fun () -> Bytes.of_string (Gen.string (Gen.int (1 lsl 20)) Gen.char ()))
+    (fun _ -> PPrint.empty)
+
+let string = deconstructible PPrint.string
+let check_size s = String.length s > 10
+
+let () =
+  let spec = bytes ^> string in
+  declare "contents" spec R.contents C.contents;
+
+  let spec = int_within (Gen.int (1 lsl 20)) ^> string in
+  declare "fixed int" spec R.fixed_int C.fixed_int
+
+let () =
+  let fuel = 10 in
+  main fuel

--- a/test/main.ml
+++ b/test/main.ml
@@ -162,6 +162,7 @@ module P = struct
 end
 
 let positive_int = int_within (Gen.int Int.max_int)
+let short_int = int_within (Gen.lt 128)
 
 let bytes =
   easily_constructible G.bytes (fun b ->
@@ -213,7 +214,7 @@ let () =
   let spec = commit ^> string in
   declare "commit" spec R.commit C.commit;
 
-  let spec = positive_int ^> string ^> int in
+  let spec = short_int ^> string ^> int in
   declare "ocaml_hash" spec R.ocaml_hash C.ocaml_hash;
 
   let spec = short_entry_list ^> string in

--- a/test/spec.ml
+++ b/test/spec.ml
@@ -1,0 +1,16 @@
+type nonrec int = int
+
+let fixed_int i =
+  let b = Bytes.create 8 in
+  Int64.of_int i |> Bytes.set_int64_be b 0;
+  Bytes.unsafe_to_string b
+
+type contents = bytes
+
+let contents b =
+  let len = Bytes.length b in
+  let len_bytes = fixed_int len in
+  let buf = Bytes.create (len + 8) in
+  Bytes.blit_string len_bytes 0 buf 0 8;
+  Bytes.blit b 0 buf 8 len;
+  Bytes.unsafe_to_string buf

--- a/test/spec.ml
+++ b/test/spec.ml
@@ -1,16 +1,185 @@
-type nonrec int = int
+(** {1 Specification implementation}
 
-let fixed_int i =
-  let b = Bytes.create 8 in
-  Int64.of_int i |> Bytes.set_int64_be b 0;
-  Bytes.unsafe_to_string b
+    This module implements the specification present in SPEC.md, independently
+    of the Irmin implementaiton. This code is not intended to be efficient, but
+    rather tries to make the correspondance with the specification as clear as
+    possible. For this reason, this code should not be used in production. *)
 
-type contents = bytes
+let ( ++ ) = ( ^ )
+let list prehash = List.fold_left (fun acc x -> acc ++ prehash x) ""
 
-let contents b =
-  let len = Bytes.length b in
-  let len_bytes = fixed_int len in
-  let buf = Bytes.create (len + 8) in
-  Bytes.blit_string len_bytes 0 buf 0 8;
-  Bytes.blit b 0 buf 8 len;
-  Bytes.unsafe_to_string buf
+(** {2 Blake2b} *)
+
+type hash = string
+
+module Blake2b = Digestif.Make_BLAKE2B (struct
+  let digest_size = 32
+end)
+
+let blake2b s = Blake2b.digest_string s |> Blake2b.to_raw_string
+
+(** {2 Integers}
+
+    See section `Integers` of SPEC.md *)
+
+let fixed_int64 i =
+  let buf = Buffer.create 8 in
+  Buffer.add_int64_be buf i;
+  Buffer.contents buf
+
+let fixed_int i = Int64.of_int i |> fixed_int64
+
+let leb128_int i =
+  (* The final size of the result may be smaller (but not greater) than 8. *)
+  let buf = Buffer.create 8 in
+  let rec loop i =
+    let b = i land 127 in
+    let i = i lsr 7 in
+    (if i <> 0 then b lor 128 else b) |> Buffer.add_uint8 buf;
+    if i = 0 then Buffer.contents buf else loop i
+  in
+  loop i
+
+(** {2 Contents}
+
+    See section `Contents` of SPEC.md *)
+
+let content c = fixed_int (Bytes.length c) ++ Bytes.unsafe_to_string c
+
+(** {2 Commits}
+
+    See the section `Commits` of SPEC.md *)
+
+type commit_metadata = { date : int64; author : string; message : string }
+
+let commit_metadata { date; author; message } =
+  fixed_int64 date
+  ++ fixed_int (String.length author)
+  ++ author
+  ++ fixed_int (String.length message)
+  ++ message
+
+type commit = { tree : hash; parents : hash list; metadata : commit_metadata }
+
+let commit { tree; parents; metadata } =
+  fixed_int 32
+  ++ tree
+  ++ fixed_int (List.length parents)
+  ++ list (fun h -> fixed_int 32 ++ h) (List.sort String.compare parents)
+  ++ commit_metadata metadata
+
+(** {2 Trees}
+
+    See section `Trees` of SPEC.md *)
+
+type entry_kind = Content | Node
+type entry = { name : string; kind : entry_kind; hash : hash }
+
+(** {3 Nodes}
+
+    When a tree contains less than 256 entries, it is encoded as a flat list of
+    entries
+
+    See section `Nodes` of SPEC.md *)
+
+type node_tree = entry list
+
+let node_entry { name; kind; hash } =
+  (match kind with
+  | Content -> "\255\000\000\000\000\000\000\000"
+  | Node -> "\000\000\000\000\000\000\000\000")
+  ++ leb128_int (String.length name)
+  ++ name
+  ++ fixed_int 32
+  ++ hash
+
+let node t =
+  assert (List.length t <= 256);
+  fixed_int (List.length t)
+  ++ list node_entry (List.sort (fun e e' -> String.compare e.name e'.name) t)
+
+(** {3 Inodes}
+
+    Trees that contain 256 entries or more are first transforned into inodes,
+    before their final encoding.
+
+    See section `Inodes values` of SPEC.md *)
+
+let inode_entry { name; kind; hash } =
+  leb128_int (String.length name)
+  ++ name
+  ++ (match kind with Content -> "\001" | Node -> "\000")
+  ++ hash
+
+type inode_value = entry list
+
+let inode_value v =
+  assert (List.length v <= 32);
+  "\000"
+  ++ String.make 1 (Char.chr (List.length v))
+  ++ list inode_entry (List.sort (fun e e' -> String.compare e.name e'.name) v)
+
+type inode_pointer = { index : int; hash : hash }
+
+let inode_pointer { index; hash } =
+  assert (index <= 32);
+  String.make 1 (Char.chr index) ++ hash
+
+type inode_tree = {
+  depth : int;
+  entries_length : int;
+  pointers : inode_pointer list;
+}
+
+let inode_tree { depth; entries_length; pointers } =
+  assert (List.length pointers <= 32);
+  "\001"
+  ++ leb128_int depth
+  ++ leb128_int entries_length
+  ++ String.make 1 (Char.chr (List.length pointers))
+  ++ list inode_pointer
+       (List.sort (fun p p' -> Int.compare p.index p'.index) pointers)
+
+(** {4 Internal tree construction} *)
+
+let ocaml_hash seed s =
+  (* TODO *)
+  Hashtbl.seeded_hash seed s
+
+let index d n = ocaml_hash d n mod 32
+
+type inode = Empty | Value of inode_value | Tree of inode_tree
+
+(** This implements the computation of $X_{d,j}$. *)
+let filter x d j = List.filter (fun { name; _ } -> index d name = j) x
+
+let rec partition d x =
+  match List.length x with
+  | 0 -> Empty
+  | n when n <= 32 -> Value x
+  | n ->
+      let tp =
+        List.init 32 (fun j ->
+            let tj = partition (succ d) (filter x d j) in
+            let tj_prehash =
+              match tj with
+              | Empty -> inode_value []
+              | Value v -> inode_value v
+              | Tree t -> inode_tree t
+            in
+            (tj, { index = j; hash = blake2b tj_prehash }))
+      in
+      let p =
+        List.filter_map
+          (fun (ti, pi) -> match ti with Empty -> None | _ -> Some pi)
+          tp
+      in
+      Tree { depth = d; entries_length = n; pointers = p }
+
+let inode x =
+  match partition 0 x with
+  | Value v -> inode_value v
+  | Tree t -> inode_tree t
+  | Empty -> (* This should not happen *) inode_value []
+
+let tree x = if List.length x > 256 then inode x else node x

--- a/test/spec.ml
+++ b/test/spec.ml
@@ -116,14 +116,14 @@ type inode_value = tree_entry list
 let inode_value v =
   assert (List.length v <= 32);
   "\000"
-  ++ String.make 1 (Char.chr (List.length v))
+  ++ leb128_int (List.length v)
   ++ list inode_entry (List.sort (fun e e' -> String.compare e.name e'.name) v)
 
 type inode_pointer = { index : int; hash : hash }
 
 let inode_pointer { index; hash } =
   assert (index <= 32);
-  String.make 1 (Char.chr index) ++ hash
+  leb128_int index ++ hash
 
 type inode_tree = {
   depth : int;
@@ -136,7 +136,7 @@ let inode_tree { depth; entries_length; pointers } =
   "\001"
   ++ leb128_int depth
   ++ leb128_int entries_length
-  ++ String.make 1 (Char.chr (List.length pointers))
+  ++ leb128_int (List.length pointers)
   ++ list inode_pointer
        (List.sort (fun p p' -> Int.compare p.index p'.index) pointers)
 

--- a/test/spec.ml
+++ b/test/spec.ml
@@ -73,7 +73,7 @@ let commit { tree; parents; metadata } =
     See section `Trees` of SPEC.md *)
 
 type entry_kind = Content | Node
-type entry = { name : string; kind : entry_kind; hash : hash }
+type tree_entry = { name : string; kind : entry_kind; hash : hash }
 
 (** {3 Nodes}
 
@@ -82,7 +82,7 @@ type entry = { name : string; kind : entry_kind; hash : hash }
 
     See section `Nodes` of SPEC.md *)
 
-type node_tree = entry list
+type node_tree = tree_entry list
 
 let node_entry { name; kind; hash } =
   (match kind with
@@ -111,7 +111,7 @@ let inode_entry { name; kind; hash } =
   ++ (match kind with Content -> "\001" | Node -> "\000")
   ++ hash
 
-type inode_value = entry list
+type inode_value = tree_entry list
 
 let inode_value v =
   assert (List.length v <= 32);

--- a/tezos-context-hash.opam
+++ b/tezos-context-hash.opam
@@ -13,18 +13,14 @@ homepage: "https://github.com/tarides/tezos-context-hash"
 bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
 depends: [
   "dune" {>= "2.7"}
-  "irmin-tezos"
   "irmin" {>= "2.7.0"}
-  "cmdliner"
-  "fmt"
-  "yojson"
+  "irmin-tezos"
   "irmin-pack"
   "ppx_irmin"
-  "alcotest" {with-test}
-  "cmdliner"
-  "irmin"
   "yojson"
-  "zarith"
+  "fmt"
+  "cmdliner"
+  "digestif"
   "monolith" {with-test}
   "pprint" {with-test}
 ]

--- a/tezos-context-hash.opam
+++ b/tezos-context-hash.opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/tarides/tezos-context-hash"
 bug-reports: "https://github.com/tarides/tezos-context-hash/issues"
 depends: [
   "dune" {>= "2.7"}
-  "irmin" {>= "2.7.0"}
+  "irmin" {>= "2.9.0"}
   "irmin-tezos"
   "irmin-pack"
   "ppx_irmin"
@@ -29,11 +29,3 @@ build: [
   ["dune" "build" "-p" name "-j" jobs "runtest" {with-test}]
 ]
 dev-repo: "git+https://github.com/tarides/tezos-context-hash.git"
-pin-depends: [
-  ["irmin.dev" "git+https://github.com/mirage/irmin.git#041f63e8bbbe78f323e75a5d6bf08201fd7906ea"]
-  ["ppx_irmin.dev" "git+https://github.com/mirage/irmin.git#041f63e8bbbe78f323e75a5d6bf08201fd7906ea"]
-  ["irmin-pack.dev" "git+https://github.com/mirage/irmin.git#041f63e8bbbe78f323e75a5d6bf08201fd7906ea"]
-  ["irmin-layers.dev" "git+https://github.com/mirage/irmin.git#041f63e8bbbe78f323e75a5d6bf08201fd7906ea"]
-  ["irmin-test.dev" "git+https://github.com/mirage/irmin.git#041f63e8bbbe78f323e75a5d6bf08201fd7906ea"]
-  ["irmin-tezos.dev" "git+https://github.com/mirage/irmin.git#041f63e8bbbe78f323e75a5d6bf08201fd7906ea"]
-]

--- a/tezos-context-hash.opam
+++ b/tezos-context-hash.opam
@@ -21,6 +21,12 @@ depends: [
   "irmin-pack"
   "ppx_irmin"
   "alcotest" {with-test}
+  "cmdliner"
+  "irmin"
+  "yojson"
+  "zarith"
+  "monolith" {with-test}
+  "pprint" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Fixes #6 

This PR adds:
- a blind(-ish) implementation of the hash specification, reusing some bits from @mattiasdrp implementation in #10.
- fuzzing using `monolith`, with the help of @n-osborne.

That lead to finding a bug in the spec: the commit parents must be sorted.